### PR TITLE
ci: upload all signed APKs and rename to app-dist-device-abi-nightly format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,22 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
           buildToolsVersion: 35.0.0
 
+      - name: Rename signed APKs
+        run: |
+          cd app/build/outputs/apk/gmsMobileUniversal/release
+          for apk in *-signed.apk; do
+            [ -f "$apk" ] || continue
+            # Extract variant name: app-gmsMobileUniversalRelease-unsigned-signed.apk -> gmsMobileUniversalRelease
+            variant=$(echo "$apk" | sed -E 's/^app-(.*)-(unsigned-)?signed\.apk$/\1/')
+            # Split camelCase into hyphenated lowercase: gmsMobileUniversalRelease -> gms-mobile-universal-release
+            nice=$(echo "$variant" | sed -E 's/([A-Z])/-\L\1/g' | sed 's/^-//')
+            # Strip build type suffix (-release), append -nightly
+            base=$(echo "$nice" | sed 's/-release$//')
+            new_name="app-${base}-nightly.apk"
+            mv "$apk" "$new_name"
+            echo "Renamed: $apk -> $new_name"
+          done
+
       - name: Get changelog
         id: changelog
         run: |
@@ -111,7 +127,7 @@ jobs:
             Automated nightly build generated on ${{ steps.tagger.outputs.formatted_date }}
 
             ${{ steps.changelog.outputs.content }}
-          files: ${{ steps.sign_app.outputs.signedFile }}
+          files: app/build/outputs/apk/gmsMobileUniversal/release/app-*-nightly.apk
           prerelease: false
 
       - name: Send Discord notification


### PR DESCRIPTION
## Problem

Release N20260811 only had 1 asset (`app-gms-mobile-universal-release-unsigned-signed.apk`) while previous releases had 12 assets.

## Root Cause

`ilharp/sign-android-release@v2.0.0` only populates `signedFile` output when there is **exactly one** signed file. When multiple APKs are produced (ABI splits), `signedFile` is empty and nothing gets uploaded.

## Changes

1. **Release glob** — changed from `${{ steps.sign_app.outputs.signedFile }}` to `app/build/outputs/apk/gmsMobileUniversal/release/*-signed.apk` so all signed APKs are uploaded
2. **Rename step** — adds a post-sign step that renames `app-gmsMobileUniversalRelease-unsigned-signed.apk` → `app-gms-mobile-universal-nightly.apk` by parsing the camelCase variant name into hyphenated lowercase

## Result

- All signed APK variants appear as release assets
- Asset names are descriptive: `app-{distribution}-{device}-{abi}-nightly.apk`